### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.vfs.watch=false
 group=gg.pufferfish.pufferfish
 version=1.20.2-R0.1-SNAPSHOT
 mcVersion=1.20.2
-paperRef=230682d51bc4078ee676751552cac56864e21b30
+paperRef=250388defed6660c57f40733c318ac90b846c264

--- a/patches/server/0001-Pufferfish-branding.patch
+++ b/patches/server/0001-Pufferfish-branding.patch
@@ -226,10 +226,10 @@ index 8f31413c939cc2b0454ad3d9a1b618dbae449d00..273d496dc9bc484e071fce7543059fe7
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5f33d18234c055393255c9c3234c6688af7a455d..e1617df14911d2b25e8045a9c287374dde201af7 100644
+index 9c08303de2891de92e06de8a939a618b7a6f7321..0456dc768228011042c5ecbe9ae3f7f968a0b96c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -267,7 +267,7 @@ import javax.annotation.Nullable; // Paper
+@@ -269,7 +269,7 @@ import javax.annotation.Nullable; // Paper
  import javax.annotation.Nonnull; // Paper
  
  public final class CraftServer implements Server {

--- a/patches/server/0006-Add-option-to-disable-books.patch
+++ b/patches/server/0006-Add-option-to-disable-books.patch
@@ -29,10 +29,10 @@ index 5b7fe3d6c2169d07b79a0937e889fc847962fdfe..ac56a5ba83184ee7b24b58cc25aa3d5a
 +	
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 34fcdeb0f4039f1fc6c4c8c593cc615560af1ba2..e82065aef31050f23eb5a533762346cb1b656704 100644
+index 65bb221993147a558995b36fb835f7b82e0eb4bd..3f5a210d7f5882543055be1f063ec1e4d92f96b5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1118,6 +1118,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -1119,6 +1119,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
  
      @Override
      public void handleEditBook(ServerboundEditBookPacket packet) {

--- a/patches/server/0016-Dynamic-Activation-of-Brain.patch
+++ b/patches/server/0016-Dynamic-Activation-of-Brain.patch
@@ -84,7 +84,7 @@ index 0b7a43b6f2ec9a69281ff38f9bef6e33878be3f8..bd3ca0af0f50b2bf1f1b95d4578c1b05
 +}
 \ No newline at end of file
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 93b6e92e490025f8ef3c154e7534bf6c278eae2a..acd140ae3b9ffd3f9283bc087744f497a47a4895 100644
+index 2405fef36498025698ea47cce85004c3facf354b..9726036b90b487bddf09891f2120893e385e84c6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -878,6 +878,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -96,7 +96,7 @@ index 93b6e92e490025f8ef3c154e7534bf6c278eae2a..acd140ae3b9ffd3f9283bc087744f497
                      if (false && this.shouldDiscardEntity(entity)) { // CraftBukkit - We prevent spawning in general, so this butchering is not needed
                          entity.discard();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9906cde792a07a433e45613518e741801026077d..764a05ad09921383e4d2a2b6def163046c76dbcf 100644
+index e544081e8214802facb77defc1e9aa765834be2a..c8c2bf587159060ed35409efce51d441b8a0525a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -434,6 +434,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -124,7 +124,7 @@ index 73871f456a85bda1e51f54986d0e61fb629822e8..ebf05a484175548c0e411adfd35fd1f6
      private String descriptionId;
      @Nullable
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index d28c477171c1b6888a45175075017d960464b5cd..9fdde46cbd88738c7dbecd96409b8031c11bacce 100644
+index 956d05e2ae59978ea9623ca0e167c0afe0b87306..bad5fbd5a35810666a7c1f0dd08400907410b4a9 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -224,10 +224,10 @@ public abstract class Mob extends LivingEntity implements Targeting {
@@ -140,7 +140,7 @@ index d28c477171c1b6888a45175075017d960464b5cd..9fdde46cbd88738c7dbecd96409b8031
              this.targetSelector.tick();
          }
      }
-@@ -913,16 +913,20 @@ public abstract class Mob extends LivingEntity implements Targeting {
+@@ -911,16 +911,20 @@ public abstract class Mob extends LivingEntity implements Targeting {
  
          if (i % 2 != 0 && this.tickCount > 1) {
              this.level().getProfiler().push("targetSelector");
@@ -328,7 +328,7 @@ index b2bc3a832c310448046ccde37a04918aa6d63197..5e43912708f9074dee1bb351efa737a7
          this.level().getProfiler().pop();
          super.customServerAiStep();
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index f555e29c7f9ea4ddb243a018bdc93d2bf1950c3c..bbcc0356b4c0470502e893cf2dc2f16936a88bc4 100644
+index cbe2a37f74f4fb2abd0b3297699e54335aaed64f..2460768aaa7b8e6d183c03c1f0f2ccd6cb61a16f 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
 @@ -142,6 +142,8 @@ public class Villager extends AbstractVillager implements ReputationEventHandler

--- a/patches/server/0021-More-debug-for-plugins-not-shutting-down-tasks.patch
+++ b/patches/server/0021-More-debug-for-plugins-not-shutting-down-tasks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More debug for plugins not shutting down tasks
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ac456c8e1387460ad01d5b9f7e86871f0229537d..5a95dcc02241d6036ee520a6a7a05e8713c6081f 100644
+index 0456dc768228011042c5ecbe9ae3f7f968a0b96c..697e74b4d966f7472f0cb3dcaca928cdde4714d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1122,6 +1122,11 @@ public final class CraftServer implements Server {
+@@ -1124,6 +1124,11 @@ public final class CraftServer implements Server {
                  plugin.getPluginMeta().getDisplayName(),
                  "This plugin is not properly shutting down its async tasks when it is being shut down. This task may throw errors during the final shutdown logs and might not complete before process dies."
              ));

--- a/patches/server/0035-Reduce-entity-fluid-lookups-if-no-fluids.patch
+++ b/patches/server/0035-Reduce-entity-fluid-lookups-if-no-fluids.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reduce entity fluid lookups if no fluids
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 18abeb44389c4b9550dd5e2fd2efb1911dd369e6..db6d5b9bd7ac9d1dd2584f785969a7b786bcc1cb 100644
+index f15d967ad88642c4e17d3570d934420013ef52ef..4a22ebd0f4e0c68e16d9184e32aae2d255c3fe77 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4363,16 +4363,18 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4342,16 +4342,18 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public boolean updateFluidHeightAndDoFluidPushing(TagKey<Fluid> tag, double speed) {
@@ -34,7 +34,7 @@ index 18abeb44389c4b9550dd5e2fd2efb1911dd369e6..db6d5b9bd7ac9d1dd2584f785969a7b7
              double d1 = 0.0D;
              boolean flag = this.isPushedByFluid();
              boolean flag1 = false;
-@@ -4380,14 +4382,61 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4359,14 +4361,61 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              int k1 = 0;
              BlockPos.MutableBlockPos blockposition_mutableblockposition = new BlockPos.MutableBlockPos();
  
@@ -102,7 +102,7 @@ index 18abeb44389c4b9550dd5e2fd2efb1911dd369e6..db6d5b9bd7ac9d1dd2584f785969a7b7
  
                              if (d2 >= axisalignedbb.minY) {
                                  flag1 = true;
-@@ -4409,9 +4458,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4388,9 +4437,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                                  // CraftBukkit end
                              }
                          }

--- a/patches/server/0038-Add-option-to-disable-out-of-order-chat.patch
+++ b/patches/server/0038-Add-option-to-disable-out-of-order-chat.patch
@@ -21,10 +21,10 @@ index 2925529336c6d080c4fe5283463f7dc3b2a40738..d6ed2faae59d035cf96a3842d99b9b80
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e82065aef31050f23eb5a533762346cb1b656704..ef6d8f787cba0db53270adedd923f9a47d435852 100644
+index 3f5a210d7f5882543055be1f063ec1e4d92f96b5..6cc9271ba058f4af759eae34e2f6e9f892b4f6da 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2274,6 +2274,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
+@@ -2275,6 +2275,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl
      }
  
      private boolean updateChatOrder(Instant timestamp) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@44057da Remove duplicate water-sensitivity damage for unaware mobs (#9908) PaperMC/Paper@f78d7ce Remove "fix-curing-zombie-villager-discount" exploit option (#9895) PaperMC/Paper@aa6c4c1 Include packet class name in packet encoding error messages (#9907) PaperMC/Paper@6592fed Use a server impl for hopper event to track get/setItem calls (#9905) PaperMC/Paper@bffb08c Deprecate Player#boostElytra (#9899) PaperMC/Paper@43c3432 Add entity API for getting the combined gene of a Panda (#9891) PaperMC/Paper@15a0de2 Make Team extend ForwardingAudience (#9852) PaperMC/Paper@0cdce89 Fix a bunch of stuff with player spawn locations (#9887) PaperMC/Paper@8a3980c Add API to get the collision shape of a block before it's placed (#9821) PaperMC/Paper@23860da Add predicate for block when raytracing (#9691) PaperMC/Paper@75d04e9 Broadcast take item packets with collector as source (#9884) PaperMC/Paper@2553f30 fix secure profile with proxy online mode (#9700) PaperMC/Paper@e289acc Add more API to LingeringPotionSplashEvent (#9901) PaperMC/Paper@8cafc07 Added missing enchantables to material tags (#9888) PaperMC/Paper@274e54b Bump tiny-remapper for Java 21 support (#9902) PaperMC/Paper@4675152 Don't leave the NearbyPlayers tracker in an entirely busted state on double-add detection PaperMC/Paper@c95bc5f Don't unpack loot table for TEs not in world (#9918) PaperMC/Paper@6675d13 Fix strikeLightningEffect powers lightning rods & clears copper (#9780) PaperMC/Paper@63e77b5 Add Enchantment cost API (#9856) PaperMC/Paper@d8847bc Updated Upstream (Bukkit/CraftBukkit) (#9922) PaperMC/Paper@dd47ec6 Add Entity Movement Direction API (#7085) PaperMC/Paper@9ee60ec Add aggressive mob API (#9838) PaperMC/Paper@531ef27 Use ApiStatus.Internal instead of Deprecated (#9042) PaperMC/Paper@9548629 Add hand to fish event for all player interactions (#9929) PaperMC/Paper@aee3830 Deprecate Material#isInteractable (#9216) PaperMC/Paper@a506b48 Fix several issues with EntityBreedEvent (#8677) PaperMC/Paper@f186318 Run the chat callback on the main thread as expected (#9935) PaperMC/Paper@ce7f068 Correct typo in javadoc (#9944) PaperMC/Paper@0a8c873 Call LivingEntity#onItemPickup before mutation (#9948) PaperMC/Paper@e5274ee Fix spawners checking max nearby entities with correct type (#8945) PaperMC/Paper@39dee1a More paper config cleanup (#9938) PaperMC/Paper@581c743 Add API to retrieve an attribute modifier from a UUID (#9924) PaperMC/Paper@8611796 Fix missing event call for entity teleport API (#9937) PaperMC/Paper@250388d add getAdvancementProgress() to PlayerAdvancementCriterionGrantEvent (#9865)