### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.vfs.watch=false
 group=gg.pufferfish.pufferfish
 version=1.20.2-R0.1-SNAPSHOT
 mcVersion=1.20.2
-paperRef=250388defed6660c57f40733c318ac90b846c264
+paperRef=faa2f475b090f3e811972eb48514a0a03647eab6

--- a/patches/api/0001-Add-Sentry.patch
+++ b/patches/api/0001-Add-Sentry.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Sentry
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index fb47a794893d5fef026a35a7c573becf74420aa0..307461526c15921d5e3fbcec63a0014b82e58850 100644
+index e827ee211e3c65dc68ac5867fd8476639df63645..359cfa1b1a9842b882e3b7688b0fd7c1d09088d3 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -46,6 +46,7 @@ dependencies {
+@@ -47,6 +47,7 @@ dependencies {
      apiAndDocs("net.kyori:adventure-text-logger-slf4j")
      api("org.apache.logging.log4j:log4j-api:$log4jVersion")
      api("org.slf4j:slf4j-api:$slf4jVersion")

--- a/patches/api/0004-Add-SIMD-utilities.patch
+++ b/patches/api/0004-Add-SIMD-utilities.patch
@@ -8,10 +8,10 @@ and API spec stability is NOT guaranteed. If you use this in plugins,
 they WILL break eventually.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 307461526c15921d5e3fbcec63a0014b82e58850..0330a20576c372c29ca4d98a2bc5b01e28303ac3 100644
+index 359cfa1b1a9842b882e3b7688b0fd7c1d09088d3..b9c75a190dbd7a90ac5ef0fbc6e6fe34806acc4e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -90,6 +90,13 @@ val generateApiVersioningFile by tasks.registering {
+@@ -107,6 +107,13 @@ val generateApiVersioningFile by tasks.registering {
      }
  }
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@eda3d53 [ci skip] Improve PlayerChatEvent Deprecation Message (#9956) PaperMC/Paper@e1cd9e5 Update paperweight to 1.5.10 and Gradle to 8.4 (#9957) PaperMC/Paper@96d5e6c Code Generation for TypedKeys (#9233) PaperMC/Paper@ed753d3 Re-add missing vanilla safeMode arg PaperMC/Paper@334b2f2 Fix max nearby entities class check (#9967) PaperMC/Paper@faa2f47 Lazily create LootContext for criterions (#9969)